### PR TITLE
Fix: Ensure confetti renders in front of success modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,6 @@
     <div id="successModal" class="modal success-modal">
         <div class="success-modal-content">
             <span class="close-button">&times;</span>
-            <div id="confettiCanvasContainer" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; overflow: hidden; z-index: -1;"></div>
             <h2>Your video is being created!</h2>
             <p class="additional-info">This will take approximately 30 minutes. You'll receive updates via Slack with further details.</p>
             <button type="button" id="createAnotherButton">Create Another Video</button>

--- a/script.js
+++ b/script.js
@@ -123,14 +123,14 @@ document.addEventListener('DOMContentLoaded', function () {
     // Success Modal Functions
     function openSuccessModal() {
         successModal.style.display = 'flex';
-        // Trigger confetti
-        const confettiCanvas = successModal.querySelector('#confettiCanvasContainer'); // Though confetti lib might append to body
+        const confettiZIndex = 1050; // Ensure this is higher than the modal's z-index
 
         // Basic confetti shot
         confetti({
             particleCount: 100,
             spread: 70,
-            origin: { y: 0.6 }
+            origin: { y: 0.6 },
+            zIndex: confettiZIndex
         });
 
         // Party poppers effect
@@ -143,14 +143,16 @@ document.addEventListener('DOMContentLoaded', function () {
                 angle: 60,
                 spread: 55,
                 origin: { x: 0 },
-                colors: colors
+                colors: colors,
+                zIndex: confettiZIndex
             });
             confetti({
                 particleCount: 2,
                 angle: 120,
                 spread: 55,
                 origin: { x: 1 },
-                colors: colors
+                colors: colors,
+                zIndex: confettiZIndex
             });
 
             if (Date.now() < end) {


### PR DESCRIPTION
- Removes an unused div with incorrect z-index from index.html.
- Updates script.js to set a higher z-index (1050) for the canvas-confetti library.

This ensures the confetti animation and party popper effects are displayed on top of the modal content, improving the visual experience.